### PR TITLE
feat: Add mlflow-server logging relation

### DIFF
--- a/modules/mlflow/cos_configuration.tf
+++ b/modules/mlflow/cos_configuration.tf
@@ -91,6 +91,21 @@ resource "juju_integration" "mlflow_server_grafana_agent_k8s_metrics_endpoint" {
   }
 }
 
+resource "juju_integration" "mlflow_server_grafana_agent_k8s_logging" {
+  count = var.cos_configuration ? 1 : 0
+  model = var.create_model ? juju_model.kubeflow[0].name : var.model
+
+  application {
+    name     = module.mlflow_server.app_name
+    endpoint = module.mlflow_server.requires.logging
+  }
+
+  application {
+    name     = var.existing_grafana_agent_name == null ? juju_application.grafana-agent-k8s-mlflow[count.index].name : var.existing_grafana_agent_name
+    endpoint = "logging-provider"
+  }
+}
+
 resource "juju_integration" "minio_grafana_agent_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
   model = var.create_model ? juju_model.kubeflow[0].name : var.model


### PR DESCRIPTION
Add logging relation after it was introduced in mlflow in https://github.com/canonical/mlflow-operator/pull/286.