### PR TITLE
feat: add config to enable/disable and set mlflow nodeport

### DIFF
--- a/modules/mlflow/README.md
+++ b/modules/mlflow/README.md
@@ -12,6 +12,7 @@ The solution module offers the following configurable inputs:
 | `<charm_name>_revision`| number | For each charm of the solution, the revision of the charm to deploy | False |
 | `cos_configuration`| bool | Boolean value that enables COS configuration | False |
 | `create_model`       | bool   | Allows skipping Juju model creation and re-using an existing model | False    |
+| `enable_mlflow_nodeport` | bool | Boolean value that enables the NodePort service for MLFlow | False |
 | `existing_grafana_agent_name`| string | Name of an existing grafana-agent-k8s deployment | False |
 | `grafana_agent_k8s_size`| string | Grafana agent database storage size | False |
 | `mlflow_minio_size`         | string | MinIO storage size allocation            | False    |

--- a/modules/mlflow/README.md
+++ b/modules/mlflow/README.md
@@ -1,4 +1,4 @@
-# Charmed MLFlow Terraform Solution
+# Charmed MLflow Terraform Solution
 
 This is a Terraform module facilitating the deployment of Charmed MLflow, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
@@ -12,12 +12,12 @@ The solution module offers the following configurable inputs:
 | `<charm_name>_revision`| number | For each charm of the solution, the revision of the charm to deploy | False |
 | `cos_configuration`| bool | Boolean value that enables COS configuration | False |
 | `create_model`       | bool   | Allows skipping Juju model creation and re-using an existing model | False    |
-| `enable_mlflow_nodeport` | bool | Boolean value that enables the NodePort service for MLFlow | False |
+| `enable_mlflow_nodeport` | bool | Boolean value that enables the NodePort service for MLflow | False |
 | `existing_grafana_agent_name`| string | Name of an existing grafana-agent-k8s deployment | False |
 | `grafana_agent_k8s_size`| string | Grafana agent database storage size | False |
 | `mlflow_minio_size`         | string | MinIO storage size allocation            | False    |
-| `mlflow_mysql_size`  | string | MySQL storage size allocation for MLFlow | False    |
-| `mlflow_nodeport` | number | The nodeport for MLFlow | False |
+| `mlflow_mysql_size`  | string | MySQL storage size allocation for MLflow | False    |
+| `mlflow_nodeport` | number | The nodeport for MLflow | False |
 | `model`              | string | Name of the Juju model for deployment    | False    |
 
 ### Outputs

--- a/modules/mlflow/README.md
+++ b/modules/mlflow/README.md
@@ -17,6 +17,7 @@ The solution module offers the following configurable inputs:
 | `grafana_agent_k8s_size`| string | Grafana agent database storage size | False |
 | `mlflow_minio_size`         | string | MinIO storage size allocation            | False    |
 | `mlflow_mysql_size`  | string | MySQL storage size allocation for MLFlow | False    |
+| `mlflow_nodeport` | number | The nodeport for MLFlow | False |
 | `model`              | string | Name of the Juju model for deployment    | False    |
 
 ### Outputs

--- a/modules/mlflow/applications.tf
+++ b/modules/mlflow/applications.tf
@@ -11,6 +11,9 @@ module "minio" {
 module "mlflow_server" {
   source     = "git::https://github.com/canonical/mlflow-operator//terraform?ref=track/2.15"
   model_name = var.create_model ? juju_model.kubeflow[0].name : var.model
+  config = {
+    enable_mlflow_nodeport = var.enable_mlflow_nodeport,
+  }
   revision   = var.mlflow_server_revision
 }
 
@@ -23,7 +26,6 @@ module "mlflow_mysql" {
   # The following config is equivalent to "constraints: mem=2G"
   config = {
     profile-limit-memory   = "2048",
-    enable_mlflow_nodeport = var.enable_mlflow_nodeport,
   }
   storage_size = var.mlflow_mysql_size
   revision     = var.mlflow_mysql_revision

--- a/modules/mlflow/applications.tf
+++ b/modules/mlflow/applications.tf
@@ -14,7 +14,7 @@ module "mlflow_server" {
   config = {
     enable_mlflow_nodeport = var.enable_mlflow_nodeport,
   }
-  revision   = var.mlflow_server_revision
+  revision = var.mlflow_server_revision
 }
 
 module "mlflow_mysql" {
@@ -25,7 +25,7 @@ module "mlflow_mysql" {
   channel         = "8.0/stable"
   # The following config is equivalent to "constraints: mem=2G"
   config = {
-    profile-limit-memory   = "2048",
+    profile-limit-memory = "2048",
   }
   storage_size = var.mlflow_mysql_size
   revision     = var.mlflow_mysql_revision

--- a/modules/mlflow/applications.tf
+++ b/modules/mlflow/applications.tf
@@ -13,6 +13,7 @@ module "mlflow_server" {
   model_name = var.create_model ? juju_model.kubeflow[0].name : var.model
   config = {
     enable_mlflow_nodeport = var.enable_mlflow_nodeport,
+    mlflow_nodeport        = var.mlflow_nodeport,
   }
   revision = var.mlflow_server_revision
 }

--- a/modules/mlflow/applications.tf
+++ b/modules/mlflow/applications.tf
@@ -22,7 +22,8 @@ module "mlflow_mysql" {
   channel         = "8.0/stable"
   # The following config is equivalent to "constraints: mem=2G"
   config = {
-    profile-limit-memory = "2048"
+    profile-limit-memory   = "2048",
+    enable_mlflow_nodeport = var.enable_mlflow_nodeport,
   }
   storage_size = var.mlflow_mysql_size
   revision     = var.mlflow_mysql_revision

--- a/modules/mlflow/applications.tf
+++ b/modules/mlflow/applications.tf
@@ -26,7 +26,7 @@ module "mlflow_mysql" {
   channel         = "8.0/stable"
   # The following config is equivalent to "constraints: mem=2G"
   config = {
-    profile-limit-memory = "2048",
+    profile-limit-memory = "2048"
   }
   storage_size = var.mlflow_mysql_size
   revision     = var.mlflow_mysql_revision

--- a/modules/mlflow/variables.tf
+++ b/modules/mlflow/variables.tf
@@ -11,7 +11,7 @@ variable "create_model" {
 }
 
 variable "enable_mlflow_nodeport" {
-  description = "Boolean value that enables the NodePort service for MLFlow"
+  description = "Boolean value that enables the NodePort service for MLflow"
   type        = bool
   default     = true
 }
@@ -59,7 +59,7 @@ variable "mlflow_mysql_size" {
 }
 
 variable "mlflow_nodeport" {
-  description = "The nodeport for MLFlow"
+  description = "The nodeport for MLflow"
   type        = number
   default     = 31380
 }

--- a/modules/mlflow/variables.tf
+++ b/modules/mlflow/variables.tf
@@ -10,6 +10,12 @@ variable "create_model" {
   default     = true
 }
 
+variable "enable_mlflow_nodeport" {
+  description = "Boolean value that enables the NodePort service for MLFlow"
+  type        = bool
+  default     = true
+}
+
 variable "existing_grafana_agent_name" {
   description = "Name of an existing grafana-agent-k8s deployment"
   type        = string
@@ -63,3 +69,4 @@ variable "model" {
   type        = string
   default     = "kubeflow"
 }
+

--- a/modules/mlflow/variables.tf
+++ b/modules/mlflow/variables.tf
@@ -58,6 +58,12 @@ variable "mlflow_mysql_size" {
   default     = "10G"
 }
 
+variable "mlflow_nodeport" {
+  description = "The nodeport for MLFlow"
+  type        = number
+  default     = 31380
+}
+
 variable "mlflow_server_revision" {
   description = "Charm revision for mlflow-server"
   type        = number


### PR DESCRIPTION
* Adds `enable_mlflow_nodeport` config option to allow disabling the creation of nodeport service.
* Adds `mlflow_nodeport` config option to set the value of the nodeport service port.

A follow-up PR will be sent to add it to [kubeflow-mlflow solution](https://github.com/canonical/charmed-kubeflow-solutions/tree/track/1.9/modules/kubeflow-mlflow)

Ref #7 