### PR TITLE
fix: update default channel for `grafana-agent-k8s`

### DIFF
--- a/modules/mlflow/cos_configuration.tf
+++ b/modules/mlflow/cos_configuration.tf
@@ -4,7 +4,7 @@ resource "juju_application" "grafana-agent-k8s-mlflow" {
   count = var.cos_configuration && var.existing_grafana_agent_name == null ? 1 : 0
   charm {
     name     = "grafana-agent-k8s"
-    channel  = "latest/stable"
+    channel  = "1/stable"
     revision = var.grafana_agent_k8s_revision
   }
   model = var.create_model ? juju_model.kubeflow[0].name : var.model


### PR DESCRIPTION
Ref https://github.com/canonical/charmed-kubeflow-chisme/issues/155

Updates the channel of `grafana-agent-k8s` charm to `1/stable` due to the `latest` channel being deprecated [as announced](https://discourse.charmhub.io/t/closing-the-latest-track-for-all-observability-charms/18054). 

Currently this results in `terraform apply` failing with:
```
╷
│ Error: Client Error
│ 
│   with juju_application.grafana-agent-k8s-mlflow[0],
│   on cos_configuration.tf line 3, in resource "juju_application" "grafana-agent-k8s-mlflow":
│    3: resource "juju_application" "grafana-agent-k8s-mlflow" {
│ 
│ Unable to create application, got error: selecting releases: charm or bundle not found for channel "latest/stable", base "amd64"
│ available releases are:
│   channel "2/edge": available bases are: ubuntu@24.04
│   channel "1/stable": available bases are: ubuntu@22.04
│   channel "1/candidate": available bases are: ubuntu@22.04
│   channel "1/beta": available bases are: ubuntu@22.04
│   channel "1/edge": available bases are: ubuntu@22.04
╵
```

We already did this update for `kubeflow` solution in https://github.com/canonical/charmed-kubeflow-solutions/pull/48, but missed updating it for `mlflow` solution.