### PR TITLE
feat: add various config options to minio and mlflow-server

### DIFF
--- a/modules/mlflow/applications.tf
+++ b/modules/mlflow/applications.tf
@@ -3,6 +3,13 @@ module "minio" {
   source     = "git::https://github.com/canonical/minio-operator//terraform?ref=track/ckf-1.10"
   model_name = var.create_model ? juju_model.kubeflow[0].name : var.model
   revision   = var.mlflow_minio_revision
+  config = {
+    access-key               = var.mlflow_minio_access_key,
+    secret-key               = var.mlflow_minio_secret_key,
+    mode                     = var.mlflow_minio_mode,
+    gateway-storage-service  = var.mlflow_minio_gateway_storage_service,
+    storage-service-endpoint = var.mlflow_minio_storage_service_endpoint,
+  }
   storage_directives = {
     minio-data = var.mlflow_minio_size
   }
@@ -15,6 +22,7 @@ module "mlflow_server" {
   config = {
     enable_mlflow_nodeport = var.enable_mlflow_nodeport,
     mlflow_nodeport        = var.mlflow_nodeport,
+    default_artifact_root  = var.mlflow_default_artifact_root,
   }
   revision = var.mlflow_server_revision
   channel  = "2.22/${var.risk}"

--- a/modules/mlflow/variables.tf
+++ b/modules/mlflow/variables.tf
@@ -45,10 +45,42 @@ variable "grafana_agent_k8s_size" {
   default     = "10G"
 }
 
+variable "mlflow_minio_access_key" {
+  description = "MinIO access key for MLflow"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "mlflow_minio_gateway_storage_service" {
+  description = "Gateway storage service configuration for MinIO when in 'gateway' mode for MLflow"
+  type        = any
+  default     = {}
+}
+
+variable "mlflow_minio_mode" {
+  description = "MinIO mode for MLflow, either 'server' or 'gateway'"
+  type        = string
+  default     = "server"
+}
+
+variable "mlflow_minio_secret_key" {
+  description = "MinIO secret key for MLflow"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "mlflow_minio_size" {
   description = "MinIO database storage size"
   type        = string
   default     = "10G"
+}
+
+variable "mlflow_minio_storage_service_endpoint" {
+  description = "MinIO storage service endpoint for MLflow, required if minio_mode is 'gateway'"
+  type        = string
+  default     = ""
 }
 
 variable "mlflow_minio_revision" {

--- a/modules/mlflow/variables.tf
+++ b/modules/mlflow/variables.tf
@@ -45,6 +45,12 @@ variable "grafana_agent_k8s_size" {
   default     = "10G"
 }
 
+variable "mlflow_default_artifact_root" {
+  description = "The default bucket MLflow uses for artifacts"
+  type        = string
+  default     = "mlflow"
+}
+
 variable "mlflow_minio_access_key" {
   description = "MinIO access key for MLflow"
   type        = string

--- a/modules/mlflow/variables.tf
+++ b/modules/mlflow/variables.tf
@@ -54,8 +54,8 @@ variable "mlflow_minio_access_key" {
 
 variable "mlflow_minio_gateway_storage_service" {
   description = "Gateway storage service configuration for MinIO when in 'gateway' mode for MLflow"
-  type        = any
-  default     = {}
+  type        = string
+  default     = ""
 }
 
 variable "mlflow_minio_mode" {


### PR DESCRIPTION
Hi team,

This PR serves purpose of adding required charm config options mainly to be able to deploy MinIO in gateway mode.
The full list of added config options are:

- MinIO 
  - access key
  - secret key
  - mode (server, gateway)
  - gateway storage service (if gateway)
  - storage service endpoint
- MLFlow
  - default artifact root

