### PR TITLE
[MISC] Backporting various commits from track/2.22 into track/2.15

### DIFF
--- a/modules/mlflow/README.md
+++ b/modules/mlflow/README.md
@@ -10,6 +10,7 @@ The solution module offers the following configurable inputs:
 | Name                | Type   | Description                             | Required |
 |---------------------|--------|-----------------------------------------|----------|
 | `<charm_name>_revision`| number | For each charm of the solution, the revision of the charm to deploy | False |
+| `risk`| string | Value for the risk to be used. Valid values are (stable, candidate, beta and edge) | False |
 | `cos_configuration`| bool | Boolean value that enables COS configuration | False |
 | `create_model`       | bool   | Allows skipping Juju model creation and re-using an existing model | False    |
 | `enable_mlflow_nodeport` | bool | Boolean value that enables the NodePort service for MLflow | False |

--- a/modules/mlflow/applications.tf
+++ b/modules/mlflow/applications.tf
@@ -6,6 +6,7 @@ module "minio" {
   storage_directives = {
     minio-data = var.mlflow_minio_size
   }
+  channel = "ckf-1.10/${var.risk}"
 }
 
 module "mlflow_server" {
@@ -16,6 +17,7 @@ module "mlflow_server" {
     mlflow_nodeport        = var.mlflow_nodeport,
   }
   revision = var.mlflow_server_revision
+  channel  = "2.22/${var.risk}"
 }
 
 module "mlflow_mysql" {

--- a/modules/mlflow/applications.tf
+++ b/modules/mlflow/applications.tf
@@ -13,7 +13,7 @@ module "minio" {
   storage_directives = {
     minio-data = var.mlflow_minio_size
   }
-  channel = "ckf-1.10/${var.risk}"
+  channel = "ckf-1.9/${var.risk}"
 }
 
 module "mlflow_server" {
@@ -25,7 +25,7 @@ module "mlflow_server" {
     default_artifact_root  = var.mlflow_default_artifact_root,
   }
   revision = var.mlflow_server_revision
-  channel  = "2.22/${var.risk}"
+  channel  = "2.15/${var.risk}"
 }
 
 module "mlflow_mysql" {

--- a/modules/mlflow/applications.tf
+++ b/modules/mlflow/applications.tf
@@ -3,6 +3,13 @@ module "minio" {
   source     = "git::https://github.com/canonical/minio-operator//terraform?ref=track/ckf-1.9"
   model_name = var.create_model ? juju_model.kubeflow[0].name : var.model
   revision   = var.mlflow_minio_revision
+  config = {
+    access-key               = var.mlflow_minio_access_key,
+    secret-key               = var.mlflow_minio_secret_key,
+    mode                     = var.mlflow_minio_mode,
+    gateway-storage-service  = var.mlflow_minio_gateway_storage_service,
+    storage-service-endpoint = var.mlflow_minio_storage_service_endpoint,
+  }
   storage_directives = {
     minio-data = var.mlflow_minio_size
   }
@@ -15,6 +22,7 @@ module "mlflow_server" {
   config = {
     enable_mlflow_nodeport = var.enable_mlflow_nodeport,
     mlflow_nodeport        = var.mlflow_nodeport,
+    default_artifact_root  = var.mlflow_default_artifact_root,
   }
   revision = var.mlflow_server_revision
   channel  = "2.22/${var.risk}"

--- a/modules/mlflow/cos_configuration.tf
+++ b/modules/mlflow/cos_configuration.tf
@@ -4,7 +4,7 @@ resource "juju_application" "grafana-agent-k8s-mlflow" {
   count = var.cos_configuration && var.existing_grafana_agent_name == null ? 1 : 0
   charm {
     name     = "grafana-agent-k8s"
-    channel  = "latest/stable"
+    channel  = "1/stable"
     revision = var.grafana_agent_k8s_revision
   }
   model = var.create_model ? juju_model.kubeflow[0].name : var.model

--- a/modules/mlflow/variables.tf
+++ b/modules/mlflow/variables.tf
@@ -1,3 +1,14 @@
+variable "risk" {
+  type        = string
+  description = "Value for the risk to be used"
+  default     = "stable"
+
+  validation {
+    condition     = contains(["stable", "candidate", "beta", "edge"], var.risk)
+    error_message = "Valid values for var: risk are (stable, candidate, beta and edge)."
+  }
+}
+
 variable "cos_configuration" {
   description = "Boolean value that enables COS configuration"
   type        = bool

--- a/modules/mlflow/variables.tf
+++ b/modules/mlflow/variables.tf
@@ -45,10 +45,48 @@ variable "grafana_agent_k8s_size" {
   default     = "10G"
 }
 
+variable "mlflow_default_artifact_root" {
+  description = "The default bucket MLflow uses for artifacts"
+  type        = string
+  default     = "mlflow"
+}
+
+variable "mlflow_minio_access_key" {
+  description = "MinIO access key for MLflow"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "mlflow_minio_gateway_storage_service" {
+  description = "Gateway storage service configuration for MinIO when in 'gateway' mode for MLflow"
+  type        = string
+  default     = ""
+}
+
+variable "mlflow_minio_mode" {
+  description = "MinIO mode for MLflow, either 'server' or 'gateway'"
+  type        = string
+  default     = "server"
+}
+
+variable "mlflow_minio_secret_key" {
+  description = "MinIO secret key for MLflow"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "mlflow_minio_size" {
   description = "MinIO database storage size"
   type        = string
   default     = "10G"
+}
+
+variable "mlflow_minio_storage_service_endpoint" {
+  description = "MinIO storage service endpoint for MLflow, required if minio_mode is 'gateway'"
+  type        = string
+  default     = ""
 }
 
 variable "mlflow_minio_revision" {


### PR DESCRIPTION
There were a few low-hanging fruit backporting to make sure our track/2.15 is aligned with 2.22 (that is still used by 1.9 KF bundle), namely:

* #12 
* #15 
* #16 