### PR TITLE
fix: set default MinIO access key for MLflow to 'minio'

### DIFF
--- a/modules/mlflow/variables.tf
+++ b/modules/mlflow/variables.tf
@@ -54,7 +54,7 @@ variable "mlflow_default_artifact_root" {
 variable "mlflow_minio_access_key" {
   description = "MinIO access key for MLflow"
   type        = string
-  default     = ""
+  default     = "minio"
   sensitive   = true
 }
 


### PR DESCRIPTION
Fix for the missing(empty) default access key as outlined in the issue https://github.com/canonical/charmed-mlflow-solutions/issues/18