### PR TITLE
[KF-8177] Use track 1.10/ for minio

### DIFF
--- a/modules/mlflow/applications.tf
+++ b/modules/mlflow/applications.tf
@@ -1,6 +1,6 @@
 module "minio" {
   app_name   = "mlflow-minio"
-  source     = "git::https://github.com/canonical/minio-operator//terraform?ref=track/ckf-1.10"
+  source     = "git::https://github.com/canonical/minio-operator//terraform?ref=track/1.10"
   model_name = var.create_model ? juju_model.kubeflow[0].name : var.model
   revision   = var.mlflow_minio_revision
   config = {

--- a/modules/mlflow/applications.tf
+++ b/modules/mlflow/applications.tf
@@ -13,7 +13,7 @@ module "minio" {
   storage_directives = {
     minio-data = var.mlflow_minio_size
   }
-  channel = "1.10/edge"
+  channel = "1.10/${var.risk}"
 }
 
 module "mlflow_server" {

--- a/modules/mlflow/applications.tf
+++ b/modules/mlflow/applications.tf
@@ -13,7 +13,7 @@ module "minio" {
   storage_directives = {
     minio-data = var.mlflow_minio_size
   }
-  channel = "ckf-1.10/${var.risk}"
+  channel = "1.10/edge"
 }
 
 module "mlflow_server" {

--- a/modules/mlflow/variables.tf
+++ b/modules/mlflow/variables.tf
@@ -92,7 +92,7 @@ variable "mlflow_minio_storage_service_endpoint" {
 variable "mlflow_minio_revision" {
   description = "Charm revision for mlflow-minio"
   type        = number
-  default     = null
+  default     = 617
 }
 
 variable "mlflow_mysql_revision" {

--- a/modules/mlflow/variables.tf
+++ b/modules/mlflow/variables.tf
@@ -92,7 +92,7 @@ variable "mlflow_minio_storage_service_endpoint" {
 variable "mlflow_minio_revision" {
   description = "Charm revision for mlflow-minio"
   type        = number
-  default     = 617
+  default     = null
 }
 
 variable "mlflow_mysql_revision" {


### PR DESCRIPTION
The charm on the 1.10 track implements side-car and ops pattern, and it is able to support back up and restore functionalities